### PR TITLE
get sut tag and git_url from metadata

### DIFF
--- a/pytest_opentmi/OpenTmiReport.py
+++ b/pytest_opentmi/OpenTmiReport.py
@@ -229,6 +229,10 @@ class OpenTmiReport:
                 result.execution.sut.commit_id = value
             elif key == 'SUT_BRANCH':
                 result.execution.sut.branch = value
+            elif key == 'SUT_TAG':
+                result.execution.sut.tag = value
+            elif key == 'SUT_GIT_URL':
+                result.execution.sut.git_url = value
 
             # push to generic metadata
             else:


### PR DESCRIPTION
earlier result.execution.sut.tag and .git_url were checked only from environment variables, this add possiblity to get tag and git_url also from test metadata.