### PR TITLE
add python 3.9 classification and pytest entry_point for package

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,7 @@ Install using pip:
 
 `pip install pytest-opentmi`
 
-Enable plugin:
-
-conftest.py:
-```
-pytest_plugins = ("pytest_opentmi.plugin",)
-```
+plugin is enabled by default.
 
 Running with pytest:
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install using pip:
 
 `pip install pytest-opentmi`
 
-plugin is enabled by default.
+plugin is enabled by using `--opentmi` CLI argument.
 
 Running with pytest:
 

--- a/example/conftest.py
+++ b/example/conftest.py
@@ -1,1 +1,2 @@
-pytest_plugins = ("pytest_opentmi.plugin",)
+# this is enabled by default when installed via pip
+# pytest_plugins = ("pytest_opentmi.plugin",)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-:copyright: (c) 2020 by Jussi Vatjus-Anttila
+:copyright: (c) 2022 by Jussi Vatjus-Anttila
 :license: MIT, see LICENSE for more details.
 """
 from setuptools import setup
@@ -48,8 +48,9 @@ setup(
         "Topic :: Utilities",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3 :: Only",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url="https://github.com/opentmi/pytest-opentmi",
     packages=["pytest_opentmi"],
     # package_data={"pytest_opentmi": ["resources/*"]},
-    # entry_points={"pytest11": ["html = pytest_opentmi.plugin"]},
+    entry_points={"pytest11": ["pytest_opentmi = pytest_opentmi.plugin"]},
     setup_requires=["setuptools_scm"],
     install_requires=["pytest>=5.0", "pytest-metadata", "opentmi-client>=0.10.1", "joblib"],
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
BREAKING CHANGE:

no need to enable plugin anymore in conftest.py (`pytest_plugins = ("pytest_opentmi.plugin",)`)